### PR TITLE
Replace "#defined" by "#define" in phoenix.hh

### DIFF
--- a/include/phoenix/phoenix.hh
+++ b/include/phoenix/phoenix.hh
@@ -13,19 +13,19 @@
 #if PHOENIX_LOG_LEVEL > 0
 #define PX_LOGE(...) phoenix::logging::log(phoenix::logging::level::error, fmt::format(__VA_ARGS__))
 #else
-#defined PX_LOGE(...)
+#define PX_LOGE(...)
 #endif
 
 #if PHOENIX_LOG_LEVEL > 1
 #define PX_LOGW(...) phoenix::logging::log(phoenix::logging::level::warn, fmt::format(__VA_ARGS__))
 #else
-#defined PX_LOGW(...)
+#define PX_LOGW(...)
 #endif
 
 #if PHOENIX_LOG_LEVEL > 2
 #define PX_LOGI(...) phoenix::logging::log(phoenix::logging::level::info, fmt::format(__VA_ARGS__))
 #else
-#defined PX_LOGI(...)
+#define PX_LOGI(...)
 #endif
 
 #if PHOENIX_LOG_LEVEL > 3


### PR DESCRIPTION
This fixes a potential compilation error when using the library with a lower log level (or none) set